### PR TITLE
Add config.mk and modify Makefiles to fix build

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,35 @@
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# Perform common configuration for building sample enclaves and hosts.
+
+# Detect compiler.
+ifneq ($(CC),cc)
+        # CC explicitly specified.
+else ifneq ($(shell $(CC) --version | grep clang),)
+        # CC is default (cc), and aliases to clang.
+else
+        # CC is default (cc), and does not alias to clang.
+        CLANG_VERSION = $(shell for v in "10" "9" "8"; do \
+                                        if [ -n "$$(command -v clang-$$v)" ]; then \
+                                                echo $$v; \
+                                                break; \
+                                        fi; \
+                                done)
+
+        ifneq ($(CLANG_VERSION),)
+                CC = clang-$(CLANG_VERSION)
+                CXX = clang++-$(CLANG_VERSION)
+        endif
+endif
+
+# Choose the right pkg-config based on CC.
+C_COMPILER = clang
+CXX_COMPILER = clang++
+ifeq ($(shell $(CC) --version | grep clang),)
+        C_COMPILER = gcc
+        CXX_COMPILER = g++
+endif
+
+# Define COMPILER for samples that use only C.
+COMPILER = $(C_COMPILER)

--- a/server_side_sgx/Makefile
+++ b/server_side_sgx/Makefile
@@ -3,6 +3,9 @@
 
 .PHONY: all build clean run simulate
 
+OE_CRYPTO_LIB := mbedtls
+export OE_CRYPTO_LIB
+
 all: build
 
 build:

--- a/server_side_sgx/enclave/Makefile
+++ b/server_side_sgx/enclave/Makefile
@@ -3,6 +3,8 @@
 
 include ../../config.mk
 
+CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libs)
+
 ifeq ($(LVI_MITIGATION), ControlFlow)
 	ifeq ($(LVI_MITIGATION_BINDIR),)
 		$(error LVI_MITIGATION_BINDIR is not set)
@@ -12,6 +14,7 @@ ifeq ($(LVI_MITIGATION), ControlFlow)
 		CC := $(LVI_MITIGATION_BINDIR)/$(CC)
 	endif
 	COMPILER := $(COMPILER)-lvi-cfg
+	CRYPTO_LDFLAGS := $(shell pkg-config oeenclave-$(COMPILER) --variable=${OE_CRYPTO_LIB}libslvicfg)
 endif
 
 CFLAGS=$(shell pkg-config oeenclave-$(COMPILER) --cflags)
@@ -31,7 +34,7 @@ build:
 	$(CC) -g -c $(CFLAGS) -DOE_API_VERSION=2 aes.c -o aes.o
 	$(CC) -g -c $(CFLAGS) -DOE_API_VERSION=2 enc.c -o enc.o
 	$(CC) -g -c $(CFLAGS) -DOE_API_VERSION=2 secure_aggregation_t.c -o secure_aggregation_t.o
-	$(CC) -o secure_aggregation_enc secure_aggregation_t.o enc.o aes.o $(LDFLAGS)
+	$(CC) -o secure_aggregation_enc secure_aggregation_t.o enc.o aes.o $(LDFLAGS) $(CRYPTO_LDFLAGS)
 
 sign:
 	oesign sign -e secure_aggregation_enc -c secure_aggregation.conf -k private.pem


### PR DESCRIPTION
The 'make build' command for server_side_sgx is failing on the newest version of OpenEnclave, as tested on a DC1s v2 Azure VM. This is probably due to OpenEnclave being updated and requiring Makefiles to change. I fixed this by adding the [config.mk](https://github.com/openenclave/openenclave/blob/master/samples/config.mk) here and updating the Makefiles following the OpenEnclave examples.

Failure log:
```
make -C enclave
make[1]: Entering directory '/home/azureuser/workplace/PPFL/server_side_sgx/enclave'
make build
make[2]: Entering directory '/home/azureuser/workplace/PPFL/server_side_sgx/enclave'
Compilers used: cc, g++
oeedger8r ../secure_aggregation.edl --trusted \
        --search-path /opt/openenclave/share/pkgconfig/../../include \
        --search-path /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx
Generating edge routine, for the Open Enclave SDK.
Processing ../secure_aggregation.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/syscall.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/epoll.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/fcntl.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/ioctl.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/poll.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/signal.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/socket.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/time.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/unistd.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/utsname.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/platform.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/attestation.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/cpu.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/debug.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/thread.edl.
Processing /opt/openenclave/share/pkgconfig/../../include/openenclave/edl/sgx/switchless.edl.
Success.
cc -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include -DOE_API_VERSION=2 aes.c -o aes.o
cc -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include -DOE_API_VERSION=2 enc.c -o enc.o
enc.c: In function ‘aes_cbc_TA’:
enc.c:39:12: warning: implicit declaration of function ‘strncmp’ [-Wimplicit-function-declaration]
         if(strncmp(xcrypt, "encrypt", 2) == 0){
            ^~~~~~~
cc -g -c -nostdinc -m64 -fPIE -ftls-model=local-exec -fvisibility=hidden -fstack-protector-strong -fno-omit-frame-pointer -ffunction-sections -fdata-sections -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty/libc -I/opt/openenclave/share/pkgconfig/../../include/openenclave/3rdparty -I/opt/openenclave/share/pkgconfig/../../include -DOE_API_VERSION=2 secure_aggregation_t.c -o secure_aggregation_t.o
cc -o secure_aggregation_enc secure_aggregation_t.o enc.o aes.o -L/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave -nostdlib -nodefaultlibs -nostartfiles -Wl,--no-undefined -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--export-dynamic -Wl,-pie -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,now -Wl,-gc-sections -loeenclave -loelibc -loesyscall -loecore
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(report.c.o): In function `oe_verify_raw_sgx_report':
/source/openenclave/enclave/sgx/report.c:69: undefined reference to `oe_aes_cmac_sign'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(link.c.o):(.data.oe_link_enclave.symbols+0x28): undefined reference to `oe_crypto_initialize'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(link.c.o):(.data.oe_link_enclave.symbols+0x38): undefined reference to `SCOSSL_ENGINE_Initialize'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(quote.c.o): In function `oe_get_quote_cert_chain_internal':
/source/openenclave/common/sgx/quote.c:416: undefined reference to `oe_cert_chain_read_pem'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(quote.c.o): In function `oe_verify_quote_internal':
/source/openenclave/common/sgx/quote.c:263: undefined reference to `oe_cert_chain_read_pem'
/source/openenclave/common/sgx/quote.c:270: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/quote.c:274: undefined reference to `oe_cert_chain_get_root_cert'
/source/openenclave/common/sgx/quote.c:278: undefined reference to `oe_cert_chain_get_cert'
/source/openenclave/common/sgx/quote.c:284: undefined reference to `oe_cert_get_ec_public_key'
/source/openenclave/common/sgx/quote.c:288: undefined reference to `oe_cert_get_ec_public_key'
/source/openenclave/common/sgx/quote.c:294: undefined reference to `oe_ec_public_key_read_pem'
/source/openenclave/common/sgx/quote.c:371: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/quote.c:372: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/quote.c:373: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/quote.c:374: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/quote.c:375: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:376: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:377: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:378: undefined reference to `oe_cert_chain_free'
/source/openenclave/common/sgx/quote.c:301: undefined reference to `oe_ec_public_key_equal'
/source/openenclave/common/sgx/quote.c:332: undefined reference to `oe_sha256_init'
/source/openenclave/common/sgx/quote.c:333: undefined reference to `oe_sha256_update'
/source/openenclave/common/sgx/quote.c:338: undefined reference to `oe_sha256_update'
/source/openenclave/common/sgx/quote.c:340: undefined reference to `oe_sha256_final'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(quote.c.o): In function `_read_public_key':
/source/openenclave/common/sgx/quote.c:176: undefined reference to `oe_ec_public_key_from_coordinates'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(quote.c.o): In function `oe_get_sgx_quote_validity':
/source/openenclave/common/sgx/quote.c:802: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:803: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:804: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/quote.c:805: undefined reference to `oe_cert_chain_free'
/source/openenclave/common/sgx/quote.c:739: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/quote.c:743: undefined reference to `oe_cert_chain_get_root_cert'
/source/openenclave/common/sgx/quote.c:747: undefined reference to `oe_cert_chain_get_cert'
/source/openenclave/common/sgx/quote.c:753: undefined reference to `oe_cert_get_validity_dates'
/source/openenclave/common/sgx/quote.c:757: undefined reference to `oe_cert_get_validity_dates'
/source/openenclave/common/sgx/quote.c:763: undefined reference to `oe_cert_get_validity_dates'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(quote.c.o): In function `_ecdsa_verify':
/source/openenclave/common/sgx/quote.c:197: undefined reference to `oe_sha256_init'
/source/openenclave/common/sgx/quote.c:198: undefined reference to `oe_sha256_update'
/source/openenclave/common/sgx/quote.c:199: undefined reference to `oe_sha256_final'
/source/openenclave/common/sgx/quote.c:201: undefined reference to `oe_ecdsa_signature_write_der'
/source/openenclave/common/sgx/quote.c:209: undefined reference to `oe_ec_public_key_verify'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(collateral.c.o): In function `oe_validate_revocation_list':
/source/openenclave/common/sgx/collateral.c:286: undefined reference to `oe_cert_chain_read_pem'
/source/openenclave/common/sgx/collateral.c:296: undefined reference to `oe_cert_chain_read_pem'
/source/openenclave/common/sgx/collateral.c:532: undefined reference to `oe_crl_free'
/source/openenclave/common/sgx/collateral.c:532: undefined reference to `oe_crl_free'
/source/openenclave/common/sgx/collateral.c:534: undefined reference to `oe_cert_chain_free'
/source/openenclave/common/sgx/collateral.c:535: undefined reference to `oe_cert_chain_free'
/source/openenclave/common/sgx/collateral.c:536: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/collateral.c:327: undefined reference to `oe_crl_read_pem'
/source/openenclave/common/sgx/collateral.c:380: undefined reference to `oe_crl_read_der'
/source/openenclave/common/sgx/collateral.c:404: undefined reference to `oe_cert_verify'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(collateral.c.o): In function `_get_crl_validity':
/source/openenclave/common/sgx/collateral.c:86: undefined reference to `oe_crl_get_update_dates'
/source/openenclave/common/sgx/collateral.c:93: undefined reference to `oe_crl_get_update_dates'
/source/openenclave/common/sgx/collateral.c:93: undefined reference to `oe_crl_get_update_dates'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(collateral.c.o): In function `oe_validate_revocation_list':
/source/openenclave/common/sgx/collateral.c:499: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/collateral.c:503: undefined reference to `oe_cert_get_validity_dates'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(sgxcertextensions.c.o): In function `_get_sgx_extension':
/source/openenclave/common/sgx/sgxcertextensions.c:391: undefined reference to `oe_cert_find_extension'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(tcbinfo.c.o): In function `oe_verify_ecdsa256_signature':
/source/openenclave/common/sgx/tcbinfo.c:1439: undefined reference to `oe_cert_chain_get_root_cert'
/source/openenclave/common/sgx/tcbinfo.c:1466: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/tcbinfo.c:1467: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/tcbinfo.c:1468: undefined reference to `oe_ec_public_key_free'
/source/openenclave/common/sgx/tcbinfo.c:1470: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/tcbinfo.c:1471: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/tcbinfo.c:1440: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/tcbinfo.c:1442: undefined reference to `oe_cert_get_ec_public_key'
/source/openenclave/common/sgx/tcbinfo.c:1443: undefined reference to `oe_cert_get_ec_public_key'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(tcbinfo.c.o): In function `_ecdsa_verify':
/source/openenclave/common/sgx/tcbinfo.c:1396: undefined reference to `oe_sha256_init'
/source/openenclave/common/sgx/tcbinfo.c:1397: undefined reference to `oe_sha256_update'
/source/openenclave/common/sgx/tcbinfo.c:1398: undefined reference to `oe_sha256_final'
/source/openenclave/common/sgx/tcbinfo.c:1400: undefined reference to `oe_ecdsa_signature_write_der'
/source/openenclave/common/sgx/tcbinfo.c:1408: undefined reference to `oe_ec_public_key_verify'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(tcbinfo.c.o): In function `oe_verify_ecdsa256_signature':
/source/openenclave/common/sgx/tcbinfo.c:1449: undefined reference to `oe_ec_public_key_read_pem'
/source/openenclave/common/sgx/tcbinfo.c:1454: undefined reference to `oe_ec_public_key_equal'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(verifier.c.o): In function `oe_verify_qve_report_and_identity':
/source/openenclave/enclave/sgx/verifier.c:213: undefined reference to `oe_sha256_init'
/source/openenclave/enclave/sgx/verifier.c:216: undefined reference to `oe_sha256_update'
/source/openenclave/enclave/sgx/verifier.c:222: undefined reference to `oe_sha256_update'
/source/openenclave/enclave/sgx/verifier.c:225: undefined reference to `oe_sha256_update'
/source/openenclave/enclave/sgx/verifier.c:229: undefined reference to `oe_sha256_update'
/source/openenclave/enclave/sgx/verifier.c:235: undefined reference to `oe_sha256_update'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(verifier.c.o):/source/openenclave/enclave/sgx/verifier.c:243: more undefined references to `oe_sha256_update' follow
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(verifier.c.o): In function `oe_verify_qve_report_and_identity':
/source/openenclave/enclave/sgx/verifier.c:248: undefined reference to `oe_sha256_final'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(sha.c.o): In function `oe_sha256':
/source/openenclave/common/sha.c:11: undefined reference to `oe_sha256_init'
/source/openenclave/common/sha.c:12: undefined reference to `oe_sha256_update'
/source/openenclave/common/sha.c:13: undefined reference to `oe_sha256_final'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(asym_keys.c.o): In function `_create_asymmetric_keypair':
/source/openenclave/enclave/asym_keys.c:129: undefined reference to `oe_kdf_derive_key'
/source/openenclave/enclave/asym_keys.c:145: undefined reference to `oe_ec_valid_raw_private_key'
/source/openenclave/enclave/asym_keys.c:151: undefined reference to `oe_kdf_derive_key'
/source/openenclave/enclave/asym_keys.c:162: undefined reference to `oe_ec_generate_key_pair_from_private'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(asym_keys.c.o): In function `_export_keypair':
/source/openenclave/enclave/asym_keys.c:191: undefined reference to `oe_ec_public_key_write_pem'
/source/openenclave/enclave/asym_keys.c:193: undefined reference to `oe_ec_private_key_write_pem'
/source/openenclave/enclave/asym_keys.c:207: undefined reference to `oe_ec_public_key_write_pem'
/source/openenclave/enclave/asym_keys.c:209: undefined reference to `oe_ec_private_key_write_pem'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(asym_keys.c.o): In function `_derive_asymmetric_key':
/source/openenclave/enclave/asym_keys.c:268: undefined reference to `oe_ec_private_key_free'
/source/openenclave/enclave/asym_keys.c:269: undefined reference to `oe_ec_public_key_free'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(endorsements.c.o): In function `oe_get_sgx_endorsements':
/source/openenclave/common/sgx/endorsements.c:390: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/endorsements.c:394: undefined reference to `oe_cert_chain_get_cert'
/source/openenclave/common/sgx/endorsements.c:418: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/endorsements.c:419: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/endorsements.c:420: undefined reference to `oe_cert_chain_free'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboeenclave.a(qeidentity.c.o): In function `oe_validate_qe_identity':
/source/openenclave/common/sgx/qeidentity.c:62: undefined reference to `oe_cert_chain_read_pem'
/source/openenclave/common/sgx/qeidentity.c:214: undefined reference to `oe_cert_chain_free'
/source/openenclave/common/sgx/qeidentity.c:215: undefined reference to `oe_cert_free'
/source/openenclave/common/sgx/qeidentity.c:90: undefined reference to `oe_cert_chain_get_leaf_cert'
/source/openenclave/common/sgx/qeidentity.c:94: undefined reference to `oe_cert_get_validity_dates'
/opt/openenclave/share/pkgconfig/../../lib/openenclave/enclave/liboecore.a(calls.c.o): In function `_handle_init_enclave':
/source/openenclave/enclave/core/sgx/calls.c:198: undefined reference to `oe_crypto_initialize'
collect2: error: ld returned 1 exit status
Makefile:27: recipe for target 'build' failed
make[2]: *** [build] Error 1
make[2]: Leaving directory '/home/azureuser/workplace/PPFL/server_side_sgx/enclave'
Makefile:22: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/azureuser/workplace/PPFL/server_side_sgx/enclave'
Makefile:9: recipe for target 'build' failed
make: *** [build] Error 2
```